### PR TITLE
Fix patching for CM11

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -72,6 +72,8 @@ while i < len(old_contents):
         in_function = True
     if ".method public static generatePackageInfo(Landroid/content/pm/PackageParser$Package;[IIJJLandroid/util/ArraySet;Landroid/content/pm/PackageUserState;I)Landroid/content/pm/PackageInfo;" in old_contents[i]:
         in_function = True
+    if ".method public static generatePackageInfo(Landroid/content/pm/PackageParser$Package;[IIJJLjava/util/HashSet;Landroid/content/pm/PackageUserState;I)Landroid/content/pm/PackageInfo;" in old_contents[i]:
+        in_function = True
     if ".end method" in old_contents[i]:
         in_function = False
     if in_function and ".line" in old_contents[i]:


### PR DESCRIPTION
In CM11 the generatePackageInfo-method accepts a HashSet (see [PackageParser.java:306](https://github.com/CyanogenMod/android_frameworks_base/blob/cm-11.0/core/java/android/content/pm/PackageParser.java#L306)),
this adjusts the code to patch this method, too.
