### PR TITLE
Faster and simpler dependencies check

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
 import os, subprocess, tempfile, time, shutil, sys
+from distutils.spawn import find_executable
 
 # check if dependencies are there
 deperrors = []
-DEVNULL = open(os.devnull, 'w')
 
 def exists(program):
-    try:
-        process = subprocess.call([program, "-h"], stdout=DEVNULL, stderr=DEVNULL)
+    if find_executable(program):
         return 0
-    except:
-        deperrors.append(program)
-        return 1
+    deperrors.append(program)
+    return 1
 
 if exists("zip") + exists("adb") + exists("java") > 0:
     print(" *** ERROR: Dependencies not satisfied.")

--- a/patch.py
+++ b/patch.py
@@ -6,7 +6,7 @@ from distutils.spawn import find_executable
 deperrors = []
 
 def exists(program):
-    if find_executable(program):
+    if find_executable(program) is not None:
         return 0
     deperrors.append(program)
     return 1


### PR DESCRIPTION
It no longer run the process itself to check its existence.
This solution works on all Python versions and on all OS and also works with executables that do not support the -h parameter.
