### PR TITLE
Start adb server before using it

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -18,6 +18,9 @@ if exists("zip") + exists("adb") + exists("java") > 0:
     print("\tPlease make sure you install:\n\t%s" % (deperrors))
     sys.exit(2)
 
+# start adb server before using it otherwise we get an unintended output inside other commands
+subprocess.check_output(["adb", "start-server"])
+
 # check if device is connected
 devices = subprocess.check_output(["adb", "devices"]).decode("utf-8")
 


### PR DESCRIPTION
Start adb server before using it otherwise we get an unintended output inside other commands (in this case adb devices).
