### PR TITLE
Fixed inconsistency in devices displaying

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -30,7 +30,7 @@ devices = [a.split("\t")[0] for a in devices]
 
 if len(devices) > 1:
     print("Enter id of device to target:")
-    id = input("\n\t".join([str(i)+" - "+a for i,a in zip(range(1, len(devices)+1), devices)]) + "\n\n> ")
+    id = input("\t"+("\n\t").join([str(i)+" - "+a for i,a in zip(range(1, len(devices)+1), devices)]) + "\n\n> ")
     chosen_one = devices[int(id)-1]
 else:
     chosen_one = devices[0]


### PR DESCRIPTION
join add the string only between values (not at the start) so you get all lines starting with a tab except the first.
This pull request fix this inconsistency.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moosd/needle/23)

<!-- Reviewable:end -->
