### PR TITLE
Copy original and patched file to the output folder / Clean temp files at the end

### DIFF
--- a/output/readme.txt
+++ b/output/readme.txt
@@ -1,0 +1,1 @@
+Here you will find the files after the patching is done.

--- a/patch.py
+++ b/patch.py
@@ -148,6 +148,7 @@ for f in glob.glob("classes*.dex"):
     subprocess.check_call(["zip", "-r", "framework.jar", f])
 
 # copy the patched file in the output folder, so if the pushing fail it can be done manually
+print(" *** Copying the patched file to the output folder...")
 shutil.copy2(os.path.join(dirpath, "framework.jar"), os.path.join(SCRIPT_DIR, "output", "framework.jar"))
 
 # push to device


### PR DESCRIPTION
- Copy original / patched file to the output folder.
- The backup of the original file is done after checking if the file is already patched so if the patch is executed again it doesn't overwrite the backup file with an already patched file.
- Clean temp files at the end.